### PR TITLE
Change from learning.cisco.com to developer.cisco.com/learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These code examples provide Python scripts to perform coding tasks.
 
-The step-by-step tutorials that work with this code are Learning Labs, displayed within the [Cisco DevNet Learning Labs system](https://learninglabs.cisco.com).
+The step-by-step tutorials that work with this code are Learning Labs, displayed within the [Cisco DevNet Learning Labs system](https://developer.cisco.com/learning).
 
 Contributions are welcome, and we are glad to review changes through pull requests. See [contributing.md](contributing.md) for details.
 

--- a/coding102-REST-python-dcloud/readme.txt
+++ b/coding102-REST-python-dcloud/readme.txt
@@ -4,8 +4,8 @@ These code samples are intended to be used with the Cisco DevNet Learning Labs. 
 walk you through the code step by step.
 
 You can find the learning labs here:
-https://learninglabs.cisco.com/lab/coding-101-rest-basics-ga/step/1
-https://learninglabs.cisco.com/lab/coding-102-rest-python-ga/step/1
+https://developer.cisco.com/learning/lab/coding-101-rest-basics-ga/step/1
+https://developer.cisco.com/learning/lab/coding-102-rest-python-ga/step/1
 
 You will need to download and setup a few items before you can begin coding along with us.
 

--- a/coding203-getting-input/get-input.py
+++ b/coding203-getting-input/get-input.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding204-reading-a-file/read-file-loop.py
+++ b/coding204-reading-a-file/read-file-loop.py
@@ -2,7 +2,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding204-reading-a-file/read-file-one-line.py
+++ b/coding204-reading-a-file/read-file-one-line.py
@@ -2,7 +2,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding204-reading-a-file/read-file-with.py
+++ b/coding204-reading-a-file/read-file-with.py
@@ -2,7 +2,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding204-reading-a-file/read-file.py
+++ b/coding204-reading-a-file/read-file.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding204-reading-a-file/read-json-from-file.py
+++ b/coding204-reading-a-file/read-json-from-file.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding205-writing-file-ga/write-file-append.py
+++ b/coding205-writing-file-ga/write-file-append.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding205-writing-file-ga/write-file-using-with.py
+++ b/coding205-writing-file-ga/write-file-using-with.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding205-writing-file-ga/write-file.py
+++ b/coding205-writing-file-ga/write-file.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding206-logging/logging-step3.py
+++ b/coding206-logging/logging-step3.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding206-logging/logging-step4.py
+++ b/coding206-logging/logging-step4.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/coding206-logging/super-simple-logging.py
+++ b/coding206-logging/super-simple-logging.py
@@ -3,7 +3,7 @@
 # amwhaley@cisco.com
 # twitter: @mandywhaley
 # http://developer.cisco.com
-# http://learninglabs.cisco.com
+# http://developer.cisco.com/learning
 # Jan 15, 2015
 
 # * THIS SAMPLE APPLICATION AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY

--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,7 @@ For public repo Learning Labs, use the issue tracker in the repo. All Learning L
 
 For private Learning Labs, use the common Issue tracker in the [CiscoDevNet/learning-labs-issues](https://github.com/CiscoDevNet/learning-labs-issues) repo.
 
-For DevNet Express events, use these three Issue tracker repos based on the content track:
+For DevNet Express events, use these Issue tracker repos based on the content track:
 * https://github.com/CiscoDevNet/devnet-express-dna-issues
 * https://github.com/CiscoDevNet/devnet-express-cc-issues
 * https://github.com/CiscoDevNet/devnet-express-dci-issues

--- a/contributing.md
+++ b/contributing.md
@@ -20,6 +20,7 @@ For DevNet Express events, use these three Issue tracker repos based on the cont
 * https://github.com/CiscoDevNet/devnet-express-dna-issues
 * https://github.com/CiscoDevNet/devnet-express-cc-issues
 * https://github.com/CiscoDevNet/devnet-express-dci-issues
+* https://github.com/CiscoDevNet/devnet-express-security-issues
 
 Use the issue tracker to suggest additions, report bugs, and ask questions.
 This is also a great way to connect with the developers of the project as well
@@ -31,8 +32,7 @@ that effort, then follow the _Changing the Learning Lab content_ guidance below.
 
 ## Changing the Learning Lab content
 
-Generally speaking, you should fork the Learning Lab repository, make changes in
-your fork, and then submit a pull request (PR). All new content should be tested
+Generally speaking, you should clone the Learning Lab repository, make changes locally, and then submit a pull request (PR). All new content should be tested
 to validate that documented tasks work correctly. Additionally, the content
 should follow the [Learning Lab Style Guide](https://github.com/CiscoDevNet/devnet-writing-guidelines/wiki/Lab-Style-Guide).
 


### PR DESCRIPTION
May not need these changes if these examples aren't used much, but will do a PR anyway.